### PR TITLE
An omex generator for an exposure that supports both CellML and SED-ML resolution

### DIFF
--- a/src/pmr2/omex/browser.py
+++ b/src/pmr2/omex/browser.py
@@ -46,6 +46,22 @@ class OmexExposureDownload(BrowserView):
         return content
 
 
+class OmexExposureGeneratedDownload(BrowserView):
+    """
+    COMBINE Archive Download tool.
+    """
+
+    def __call__(self):
+        tool = zope.component.getUtility(IExposureDownloadTool, name='omex_generated')
+        content = tool.download(self.context, self.request)
+        self.request.response.setHeader('Content-Type', tool.mimetype)
+        self.request.response.setHeader('Content-Length', len(content))
+        self.request.response.setHeader('Content-Disposition',
+            'attachment; filename="%s%s"' % (
+                self.context.title_or_id(), tool.suffix))
+        return content
+
+
 class WebCatToolView(SimplePage):
 
     template = ViewPageTemplateFile('webcat_view.pt')

--- a/src/pmr2/omex/configure.zcml
+++ b/src/pmr2/omex/configure.zcml
@@ -4,6 +4,7 @@
     i18n_domain="pmr2.omex">
 
   <include file="annotation.zcml"/>
+  <include package=".exposure"/>
 
   <utility
       provides="pmr2.app.workspace.interfaces.IStorageArchiver"

--- a/src/pmr2/omex/configure.zcml
+++ b/src/pmr2/omex/configure.zcml
@@ -19,6 +19,12 @@
       />
 
   <utility
+      provides="pmr2.app.exposure.interfaces.IExposureDownloadTool"
+      factory=".utility.OmexExposureGeneratedDownloadTool"
+      name="omex_generated"
+      />
+
+  <utility
       provides="pmr2.app.exposure.interfaces.IExposureFileTool"
       factory=".utility.WebCatLinkTool"
       name="webcat_tool"
@@ -34,6 +40,13 @@
       for="pmr2.app.exposure.interfaces.IExposureFile"
       name="download_omex"
       class=".browser.OmexExposureDownload"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="pmr2.app.exposure.interfaces.IExposure"
+      name="download_generated_omex"
+      class=".browser.OmexExposureGeneratedDownload"
       permission="zope2.View"
       />
 

--- a/src/pmr2/omex/exposure/cellml.py
+++ b/src/pmr2/omex/exposure/cellml.py
@@ -8,6 +8,7 @@ from zope.interface import implementer
 from pmr2.app.exposure.interfaces import IExposureSourceAdapter
 
 from cellml.api.pmr2.interfaces import ICellMLAPIUtility
+from cellml.api.pmr2.interfaces import CellMLLoaderError
 from cellml.pmr2.urlopener import make_pmr_path
 
 from pmr2.omex.exposure.interfaces import IExposureFileLoader
@@ -29,7 +30,11 @@ class TrackedCellMLLoader(object):
             '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
         target = make_pmr_path(
             '/'.join(workspace.getPhysicalPath()), exposure.commit_id, path)
-        model = cu.loadModel(target, loader=urlopener)
+        try:
+            cu.loadModel(target, loader=urlopener)
+        except CellMLLoaderError:
+            # we only care that the imports are loaded once
+            pass
         # the map of loaded modules
         return {
             key[len(root):]: value

--- a/src/pmr2/omex/exposure/cellml.py
+++ b/src/pmr2/omex/exposure/cellml.py
@@ -8,42 +8,17 @@ from zope.interface import implementer
 from pmr2.app.exposure.interfaces import IExposureSourceAdapter
 
 from cellml.api.pmr2.interfaces import ICellMLAPIUtility
-from cellml.pmr2.urlopener import PmrUrlOpener
 from cellml.pmr2.urlopener import make_pmr_path
 
-# find all files in side the exposure, see if CellML/sedml
+from pmr2.omex.exposure.interfaces import IExposureFileLoader
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
 
 
-class LoggedPmrUrlOpener(PmrUrlOpener):
-
-    def __init__(self):
-        super(LoggedPmrUrlOpener, self).__init__()
-        self.loaded = {}
-        self.external = []
-        # for ensuring that the recursive resolver only applies at the
-        # outermost call.
-        self.loading = False
-
-    def loadURL(self, location, headers=None):
-        p = urlparse.urlparse(location)
-        # ensure that only the outermost caller is tracking the loaded
-        # urls
-        tracking = not self.loading
-        if tracking and not p.scheme == 'pmr':
-            tracking = False
-            self.external.append(location)
-
-        self.loading = True
-        result = super(LoggedPmrUrlOpener, self).loadURL(location)
-        if tracking:
-            self.loading = False
-            self.loaded[location] = result
-        return result
-
-
+@implementer(IExposureFileLoader)
 class TrackedCellMLLoader(object):
 
     def load(self, exposure_file, urlopener=None):
+        urlopener = urlopener or LoggedPmrUrlOpener()
         cu = zope.component.getUtility(ICellMLAPIUtility)
         sa = zope.component.getAdapter(exposure_file, IExposureSourceAdapter)
         exposure, workspace, path = sa.source()
@@ -54,7 +29,6 @@ class TrackedCellMLLoader(object):
             '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
         target = make_pmr_path(
             '/'.join(workspace.getPhysicalPath()), exposure.commit_id, path)
-        urlopener = urlopener or LoggedPmrUrlOpener()
         model = cu.loadModel(target, loader=urlopener)
         # the map of loaded modules
         return {

--- a/src/pmr2/omex/exposure/cellml.py
+++ b/src/pmr2/omex/exposure/cellml.py
@@ -11,6 +11,7 @@ from cellml.api.pmr2.interfaces import ICellMLAPIUtility
 from cellml.api.pmr2.interfaces import CellMLLoaderError
 from cellml.pmr2.urlopener import make_pmr_path
 
+from pmr2.omex.exposure.interfaces import DuplicateURLError
 from pmr2.omex.exposure.interfaces import IExposureFileLoader
 from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
 from pmr2.omex.exposure.default import ExposureFileLoader
@@ -23,7 +24,7 @@ class TrackedCellMLLoader(ExposureFileLoader):
         cu = zope.component.getUtility(ICellMLAPIUtility)
         try:
             cu.loadModel(urn, loader=urlopener)
-        except CellMLLoaderError:
-            # we only care that the imports are loaded once
-            # nor do we care if the model don't actually load...
+        except (DuplicateURLError, CellMLLoaderError):
+            # we only care that the model and its imports are loaded at
+            # least once nor do we care if the model is invalid...
             pass

--- a/src/pmr2/omex/exposure/cellml.py
+++ b/src/pmr2/omex/exposure/cellml.py
@@ -13,33 +13,16 @@ from cellml.pmr2.urlopener import make_pmr_path
 
 from pmr2.omex.exposure.interfaces import IExposureFileLoader
 from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
+from pmr2.omex.exposure.default import ExposureFileLoader
 
 
 @implementer(IExposureFileLoader)
-class TrackedCellMLLoader(object):
+class TrackedCellMLLoader(ExposureFileLoader):
 
-    def load(self, exposure_file, urlopener=None):
-        urlopener = urlopener or LoggedPmrUrlOpener()
-        sa = zope.component.getAdapter(exposure_file, IExposureSourceAdapter)
-        exposure, workspace, path = sa.source()
-        # need this to resolve.
-        root = make_pmr_path(
-            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
-        target = make_pmr_path(
-            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, path)
-        self.loadTarget(target, urlopener)
-        # the map of loaded modules
-        return {
-            key[len(root):]: value
-            for key, value in urlopener.loaded.items()
-            if key.startswith(root)
-        }
-
-    def loadTarget(self, target, urlopener=None):
-        urlopener = urlopener or LoggedPmrUrlOpener()
+    def loadTarget(self, urn, urlopener):
         cu = zope.component.getUtility(ICellMLAPIUtility)
         try:
-            cu.loadModel(target, loader=urlopener)
+            cu.loadModel(urn, loader=urlopener)
         except CellMLLoaderError:
             # we only care that the imports are loaded once
             # nor do we care if the model don't actually load...

--- a/src/pmr2/omex/exposure/cellml.py
+++ b/src/pmr2/omex/exposure/cellml.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import
+
+import urlparse
+
+import zope.component
+from zope.interface import implementer
+
+from pmr2.app.exposure.interfaces import IExposureSourceAdapter
+
+from cellml.api.pmr2.interfaces import ICellMLAPIUtility
+from cellml.pmr2.urlopener import PmrUrlOpener
+from cellml.pmr2.urlopener import make_pmr_path
+
+# find all files in side the exposure, see if CellML/sedml
+
+
+class LoggedPmrUrlOpener(PmrUrlOpener):
+
+    def __init__(self):
+        super(LoggedPmrUrlOpener, self).__init__()
+        self.loaded = {}
+        self.external = []
+        # for ensuring that the recursive resolver only applies at the
+        # outermost call.
+        self.loading = False
+
+    def loadURL(self, location, headers=None):
+        p = urlparse.urlparse(location)
+        # ensure that only the outermost caller is tracking the loaded
+        # urls
+        tracking = not self.loading
+        if tracking and not p.scheme == 'pmr':
+            tracking = False
+            self.external.append(location)
+
+        self.loading = True
+        result = super(LoggedPmrUrlOpener, self).loadURL(location)
+        if tracking:
+            self.loading = False
+            self.loaded[location] = result
+        return result
+
+
+class TrackedCellMLLoader(object):
+
+    def load(self, exposure_file, urlopener=None):
+        cu = zope.component.getUtility(ICellMLAPIUtility)
+        sa = zope.component.getAdapter(exposure_file, IExposureSourceAdapter)
+        exposure, workspace, path = sa.source()
+        modelfile = '%s/@@%s/%s/%s' % (workspace.absolute_url(),
+            'rawfile', exposure.commit_id, path)
+        # need this to resolve.
+        root = make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
+        target = make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, path)
+        urlopener = urlopener or LoggedPmrUrlOpener()
+        model = cu.loadModel(target, loader=urlopener)
+        # the map of loaded modules
+        return {
+            key[len(root):]: value
+            for key, value in urlopener.loaded.items()
+            if key.startswith(root)
+        }

--- a/src/pmr2/omex/exposure/configure.zcml
+++ b/src/pmr2/omex/exposure/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="pmr2.omex">
+
+  <utility
+      provides=".interfaces.IExposureFileLoader"
+      factory=".cellml.TrackedCellMLLoader"
+      name="cellml"
+      />
+
+  <utility
+      provides=".interfaces.IExposureFileLoader"
+      factory=".sedml.TrackedSedMLLoader"
+      name="sedml"
+      />
+
+</configure>

--- a/src/pmr2/omex/exposure/configure.zcml
+++ b/src/pmr2/omex/exposure/configure.zcml
@@ -5,6 +5,12 @@
 
   <utility
       provides=".interfaces.IExposureFileLoader"
+      factory=".default.ExposureFileLoader"
+      name=""
+      />
+
+  <utility
+      provides=".interfaces.IExposureFileLoader"
       factory=".cellml.TrackedCellMLLoader"
       name="cellml"
       />

--- a/src/pmr2/omex/exposure/default.py
+++ b/src/pmr2/omex/exposure/default.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+import zope.component
+from zope.interface import implementer
+
+from pmr2.app.exposure.interfaces import IExposureSourceAdapter
+
+from cellml.pmr2.urlopener import make_pmr_path
+
+from pmr2.omex.exposure.interfaces import IExposureFileLoader
+from pmr2.omex.exposure.interfaces import DuplicateURLError
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
+
+
+@implementer(IExposureFileLoader)
+class ExposureFileLoader(object):
+
+    def load(self, exposure_file, urlopener=None):
+        urlopener = urlopener or LoggedPmrUrlOpener()
+        sa = zope.component.getAdapter(exposure_file, IExposureSourceAdapter)
+        # rather than processing the file directly, let the urlopener
+        # track the process
+        exposure, workspace, path = sa.source()
+        # need this to resolve.
+        root = make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
+        urn = make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, path)
+        self.loadTarget(urn, urlopener)
+
+        return {
+            key[len(root):]: value
+            for key, value in urlopener.loaded.items()
+            if key.startswith(root)
+        }
+
+    def loadTarget(self, urn, urlopener):
+        try:
+            return urlopener.loadURL(urn)
+        except DuplicateURLError:
+            pass

--- a/src/pmr2/omex/exposure/interfaces.py
+++ b/src/pmr2/omex/exposure/interfaces.py
@@ -20,3 +20,9 @@ class IExposureFileLoader(zope.interface.Interface):
         loaded files; takes an optional urlopener that would provide the
         logged loaded field.
         """
+
+    def loadTarget(urn, urlopener):
+        """
+        Load the provided urn with the urlopener in order to register
+        the urn with the urlopener
+        """

--- a/src/pmr2/omex/exposure/interfaces.py
+++ b/src/pmr2/omex/exposure/interfaces.py
@@ -1,4 +1,15 @@
+from __future__ import absolute_import
+
+from urllib2 import URLError
 import zope.interface
+
+from cellml.api.pmr2.interfaces import CellMLLoaderError
+
+
+class DuplicateURLError(URLError):
+    """
+    For aborting on duplicate URL
+    """
 
 
 class IExposureFileLoader(zope.interface.Interface):

--- a/src/pmr2/omex/exposure/interfaces.py
+++ b/src/pmr2/omex/exposure/interfaces.py
@@ -1,0 +1,11 @@
+import zope.interface
+
+
+class IExposureFileLoader(zope.interface.Interface):
+
+    def load(exposure_file, urlopener=None):
+        """
+        Load the provided exposure file and produce a mapping of all
+        loaded files; takes an optional urlopener that would provide the
+        logged loaded field.
+        """

--- a/src/pmr2/omex/exposure/interfaces.py
+++ b/src/pmr2/omex/exposure/interfaces.py
@@ -8,7 +8,7 @@ from cellml.api.pmr2.interfaces import CellMLLoaderError
 
 class DuplicateURLError(URLError):
     """
-    For aborting on duplicate URL
+    For signaling an abort on a duplicate URL to be loaded.
     """
 
 

--- a/src/pmr2/omex/exposure/sedml.py
+++ b/src/pmr2/omex/exposure/sedml.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import
+
+from urlparse import urlparse
+from io import BytesIO
+from lxml import etree
+
+import zope.component
+from zope.interface import implementer
+
+from pmr2.app.exposure.interfaces import IExposureSourceAdapter
+
+from cellml.pmr2.urlopener import make_pmr_path
+
+from pmr2.omex.exposure.interfaces import IExposureFileLoader
+from pmr2.omex.exposure.interfaces import DuplicateURLError
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
+
+
+@implementer(IExposureFileLoader)
+class TrackedSedMLLoader(object):
+
+    def load(self, exposure_file, urlopener=None):
+        urlopener = urlopener or LoggedPmrUrlOpener()
+        sa = zope.component.getAdapter(exposure_file, IExposureSourceAdapter)
+        # rather than processing the file directly, let the urlopener
+        # track the process
+        exposure, workspace, path = sa.source()
+        # need this to resolve.
+        root = make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
+        sedml = urlopener.loadURL(make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, path))
+
+        dom = etree.XML(sedml)
+        ns = {'_': dom.nsmap[None]}
+        targets = []
+        targets.extend(dom.xpath('//_:model/@source', namespaces=ns))
+        targets.extend(dom.xpath('//_:dataDescription/@source', namespaces=ns))
+
+        for target in targets:
+            parsed = urlparse(target)
+            if parsed.scheme or parsed.netloc:
+                # do not load remote resources
+                continue
+
+            # TODO maybe splitext and just have a default?
+            # as a demonstration with one specific target we can get away
+            # with this...
+            resolved = make_pmr_path(
+                '/'.join(workspace.getPhysicalPath()), exposure.commit_id,
+                target,
+            )
+
+            if target.endswith('.cellml'):
+                utility = zope.component.queryUtility(
+                    IExposureFileLoader, name='cellml')
+                if utility:
+                    utility.loadTarget(resolved, urlopener=urlopener)
+                    continue
+
+            try:
+                urlopener.loadURL(resolved)
+            except DuplicateURLError:
+                pass
+
+        # TODO parse sedml for sources.
+        # the map of loaded modules
+        return {
+            key[len(root):]: value
+            for key, value in urlopener.loaded.items()
+            if key.startswith(root)
+        }
+

--- a/src/pmr2/omex/exposure/sedml.py
+++ b/src/pmr2/omex/exposure/sedml.py
@@ -20,7 +20,7 @@ from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
 @implementer(IExposureFileLoader)
 class TrackedSedMLLoader(ExposureFileLoader):
 
-    def process_sedml(self, sedml, exposure, workspace, urlopener):
+    def process_sedml(self, sedml, source, urlopener):
         dom = etree.XML(sedml)
         ns = {'_': dom.nsmap[None]}
         targets = []
@@ -33,14 +33,11 @@ class TrackedSedMLLoader(ExposureFileLoader):
                 # do not load remote resources
                 continue
 
+            resolved = urlopener.urljoin(source, target)
+
             # TODO maybe splitext and just have a default?
             # as a demonstration with one specific target we can get away
             # with this...
-            resolved = make_pmr_path(
-                '/'.join(workspace.getPhysicalPath()), exposure.commit_id,
-                target,
-            )
-
             if target.endswith('.cellml'):
                 utility = zope.component.queryUtility(
                     IExposureFileLoader, name='cellml')
@@ -67,7 +64,7 @@ class TrackedSedMLLoader(ExposureFileLoader):
         except DuplicateURLError:
             pass
         else:
-            self.process_sedml(sedml, exposure, workspace, urlopener)
+            self.process_sedml(sedml, urn, urlopener)
 
         return {
             key[len(root):]: value

--- a/src/pmr2/omex/exposure/urlopener.py
+++ b/src/pmr2/omex/exposure/urlopener.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+import urlparse
+
+import zope.component
+from zope.interface import implementer
+
+from cellml.pmr2.urlopener import PmrUrlOpener
+
+
+class LoggedPmrUrlOpener(PmrUrlOpener):
+
+    def __init__(self):
+        super(LoggedPmrUrlOpener, self).__init__()
+        self.loaded = {}
+        self.external = []
+        # for ensuring that the recursive resolver only applies at the
+        # outermost call.
+        self.loading = False
+
+    def loadURL(self, location, headers=None):
+        p = urlparse.urlparse(location)
+        # ensure that only the outermost caller is tracking the loaded
+        # urls
+        tracking = not self.loading
+        if tracking and not p.scheme == 'pmr':
+            tracking = False
+            self.external.append(location)
+
+        self.loading = True
+        result = super(LoggedPmrUrlOpener, self).loadURL(location)
+        if tracking:
+            self.loading = False
+            self.loaded[location] = result
+        return result

--- a/src/pmr2/omex/exposure/urlopener.py
+++ b/src/pmr2/omex/exposure/urlopener.py
@@ -6,6 +6,7 @@ import zope.component
 from zope.interface import implementer
 
 from cellml.pmr2.urlopener import PmrUrlOpener
+from pmr2.omex.exposure.interfaces import DuplicateURLError
 
 
 class LoggedPmrUrlOpener(PmrUrlOpener):
@@ -19,6 +20,10 @@ class LoggedPmrUrlOpener(PmrUrlOpener):
         self.loading = False
 
     def loadURL(self, location, headers=None):
+        if location in self.loaded:
+            raise DuplicateURLError(
+                '%s already loaded by this loader' % location)
+
         p = urlparse.urlparse(location)
         # ensure that only the outermost caller is tracking the loaded
         # urls

--- a/src/pmr2/omex/exposure/utility.py
+++ b/src/pmr2/omex/exposure/utility.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from os.path import splitext
-from zope.component import getUtility, getAdapter
+from zope.component import getUtility, queryUtility, getAdapter
 from Products.CMFCore.utils import getToolByName
 
 from pmr2.app.exposure.interfaces import IExposureSourceAdapter
@@ -22,7 +22,10 @@ class ExposureGeneratedOmexArchiver(object):
         """
 
         extname = splitext(exposure_file.getPhysicalPath()[-1])[1][1:]
-        utility = getUtility(IExposureFileLoader, name=extname)
+        utility = queryUtility(
+            IExposureFileLoader, name=extname,
+            default=getUtility(IExposureFileLoader)
+        )
         utility.load(exposure_file, urlopener)
 
     def archive_exposure(self, exposure):

--- a/src/pmr2/omex/exposure/utility.py
+++ b/src/pmr2/omex/exposure/utility.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+from os.path import splitext
+from zope.component import getUtility, getAdapter
+from Products.CMFCore.utils import getToolByName
+
+from pmr2.app.exposure.interfaces import IExposureSourceAdapter
+from cellml.pmr2.urlopener import make_pmr_path
+from pmr2.omex.exposure.interfaces import IExposureFileLoader
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
+from pmr2.omex.omex import generate_manifest, _create_zip
+
+
+class ExposureGeneratedOmexArchiver(object):
+    """
+    The exposure to omex archive builder.
+    """
+
+    def process_exposure_file(self, exposure_file, urlopener):
+        """
+        Resolve the correct helper with the exposure file.
+        """
+
+        extname = splitext(exposure_file.getPhysicalPath()[-1])[1][1:]
+        utility = getUtility(IExposureFileLoader, name=extname)
+        utility.load(exposure_file, urlopener)
+
+    def archive_exposure(self, exposure):
+        urlopener = LoggedPmrUrlOpener()
+        catalog = getToolByName(exposure, 'portal_catalog')
+        path = '/'.join(exposure.getPhysicalPath())
+        for target in catalog(path=path, portal_type="ExposureFile"):
+            self.process_exposure_file(target.getObject(), urlopener)
+
+        # process urlopener data into archive
+        filemap = {
+            'manifest.xml': '',  # placeholder
+        }
+        # TODO figure out how to refactor this chunk of copypasta code
+        # needed in various places.
+        sa = getAdapter(exposure, IExposureSourceAdapter)
+        exposure, workspace, path = sa.source()
+        root = make_pmr_path(
+            '/'.join(workspace.getPhysicalPath()), exposure.commit_id, '')
+        filemap.update({
+            key[len(root):]: value
+            for key, value in urlopener.loaded.items()
+            if key.startswith(root)
+        })
+        filemap['manifest.xml'] = generate_manifest(filemap)
+        return _create_zip(filemap.items())

--- a/src/pmr2/omex/exposure/utility.py
+++ b/src/pmr2/omex/exposure/utility.py
@@ -37,6 +37,7 @@ class ExposureGeneratedOmexArchiver(object):
 
         # process urlopener data into archive
         filemap = {
+            '.': '',  # placeholder for parent entry
         }
         # TODO figure out how to refactor this chunk of copypasta code
         # needed in various places.

--- a/src/pmr2/omex/exposure/utility.py
+++ b/src/pmr2/omex/exposure/utility.py
@@ -37,7 +37,6 @@ class ExposureGeneratedOmexArchiver(object):
 
         # process urlopener data into archive
         filemap = {
-            'manifest.xml': '',  # placeholder
         }
         # TODO figure out how to refactor this chunk of copypasta code
         # needed in various places.

--- a/src/pmr2/omex/omex.py
+++ b/src/pmr2/omex/omex.py
@@ -86,6 +86,8 @@ def _create_zip(filemap):
     stream = StringIO()
     zf = zipfile.ZipFile(stream, mode='w')
     for path, contents in filemap:
+        if path == '.':
+            continue
         znfo = zipfile.ZipInfo(path)
         znfo.file_size = len(contents)
         znfo.compress_type = zipfile.ZIP_DEFLATED
@@ -135,7 +137,9 @@ def generate_manifest(filemap):
     ''').strip()
     output = [omex_header]
     for name, content in sorted(filemap.items()):
-        if name == 'manifest.xml':
+        if name == '.':
+            fmt = "http://identifiers.org/combine.specifications/omex"
+        elif name == 'manifest.xml':
             fmt = "http://identifiers.org/combine.specifications/omex-manifest"
         else:
             fext = splitext(name)[-1]

--- a/src/pmr2/omex/omex.py
+++ b/src/pmr2/omex/omex.py
@@ -1,5 +1,8 @@
 from cStringIO import StringIO
+from os.path import splitext
 from urlparse import urlparse
+from textwrap import dedent
+import mimetypes
 import zipfile
 
 from lxml import etree
@@ -111,3 +114,38 @@ def parse_manifest(raw_manifest):
 
     # assert that 'manifest.xml' is included?
     return locations
+
+def generate_manifest(filemap):
+    identifiers_org = {
+        '.cellml': "http://identifiers.org/combine.specifications/cellml",
+        '.sbml': "http://identifiers.org/combine.specifications/sbml",
+        '.sedml': "http://identifiers.org/combine.specifications/sedml",
+        '.rdf': "http://identifiers.org/combine.specifications/omex-metadata",
+    }
+    omex_header = dedent('''
+    <?xml version='1.0' encoding='utf-8' standalone='yes'?>
+    <omexManifest
+        xmlns="http://identifiers.org/combine.specifications/omex-manifest">
+    ''').strip()
+    omex_footer = dedent('''
+    </omexManifest>
+    ''').strip()
+    omex_line = dedent('''
+    <content location="{location}" format="{format}" />
+    ''').strip()
+    output = [omex_header]
+    for name, content in sorted(filemap.items()):
+        if name == 'manifest.xml':
+            fmt = "http://identifiers.org/combine.specifications/omex-manifest"
+        else:
+            fext = splitext(name)[-1]
+            fmt = identifiers_org.get(
+                fext, "http://purl.org/NET/mediatypes/%s" % (
+                    mimetypes.guess_type(name)[0]))
+
+        output.append(omex_line.format(
+            location=name,
+            format=fmt,
+        ))
+    output.append(omex_footer)
+    return '\n'.join(output)

--- a/src/pmr2/omex/testing/layer.py
+++ b/src/pmr2/omex/testing/layer.py
@@ -40,6 +40,11 @@ class OmexBaseLayer(PloneSandboxLayer):
         w.storage = 'dummy_storage'
         portal.workspace['subrepo'] = w
 
+        su._loadDir('sedml', join(dirname(__file__), 'sedml'))
+        w = Workspace('sedml')
+        w.storage = 'dummy_storage'
+        portal.workspace['sedml'] = w
+
         raw = su._dummy_storage_data['omex_base']
         raw.append({})
         raw[-1].update(raw[2])
@@ -49,7 +54,6 @@ class OmexBaseLayer(PloneSandboxLayer):
             # XXX note the lack of portal in vhost
             'location': 'http://vhost/workspace/subrepo',
         }
-
 
     def tearDownZope(self, app):
         z2.uninstallProduct(app, 'pmr2.omex')

--- a/src/pmr2/omex/testing/sedml/0/demo.cellml
+++ b/src/pmr2/omex/testing/sedml/0/demo.cellml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<model xmlns="http://www.cellml.org/cellml/1.1#" name="demo" cmeta:id="demo"
+    xmlns:cellml="http://www.cellml.org/cellml/1.1#">
+</model>

--- a/src/pmr2/omex/testing/sedml/0/simple.sedml
+++ b/src/pmr2/omex/testing/sedml/0/simple.sedml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+  <listOfModels>
+    <model id="model3" language="urn:sedml:language:cellml" source="./demo.cellml"/>
+  </listOfModels>
+</sedML>

--- a/src/pmr2/omex/testing/sedml/0/simulation.sedml
+++ b/src/pmr2/omex/testing/sedml/0/simulation.sedml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version3" level="1" version="3">
+  <listOfDataDescriptions>
+    <dataDescription id="Data1" name="Table" source="table.csv" format="urn:sedml:format:csv">
+    </dataDescription>
+  </listOfDataDescriptions>
+  <listOfModels>
+    <model id="model1" language="urn:sedml:language:sbml" source="urn:miriam:biomodels.db:BIOMD0000000140"/>
+    <model id="model2" language="urn:sedml:language:cellml" source="http://nohost/plone/workspace/main_model/model.cellml"/>
+    <model id="model3" language="urn:sedml:language:cellml" source="demo.cellml"/>
+    <model id="model4" language="urn:sedml:language:cellml" source="embed/multi.cellml"/>
+  </listOfModels>
+</sedML>

--- a/src/pmr2/omex/tests/test_exposure_cellml.py
+++ b/src/pmr2/omex/tests/test_exposure_cellml.py
@@ -116,11 +116,11 @@ class LoaderTestCase(TestCase):
         su = getUtility(IStorageUtility, name='dummy_storage')
         src = su._dummy_storage_data['demo_model'][0]['multi.cellml']
 
-        loaded = []
+        external_loaded = []
 
         # patch urllib2.urlopen to return this exact result
         def urlopen(request):
-            loaded.append(request.get_full_url())
+            external_loaded.append(request.get_full_url())
             return BytesIO(
                 su._dummy_storage_data['main_model'][0]['model.cellml'])
 
@@ -163,9 +163,7 @@ class LoaderTestCase(TestCase):
         # will still be loaded.
         self.assertEqual([
             'http://nohost/plone/workspace/main_model/rawfile/0/model.cellml',
-            'http://nohost/plone/workspace/main_model/rawfile/0/model.cellml',
-            'http://nohost/plone/workspace/main_model/rawfile/0/model.cellml',
-        ], loaded)
+        ], external_loaded)
 
 
 def test_suite():

--- a/src/pmr2/omex/tests/test_exposure_cellml.py
+++ b/src/pmr2/omex/tests/test_exposure_cellml.py
@@ -9,7 +9,7 @@ from pmr2.app.exposure.browser.browser import ExposureAddForm
 from pmr2.app.exposure.browser.browser import ExposureFileGenForm
 from pmr2.testing.base import TestRequest
 
-from pmr2.omex.exposure.cellml import LoggedPmrUrlOpener
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
 from pmr2.omex.exposure.cellml import TrackedCellMLLoader
 
 from cellml.pmr2.tests.layer import CELLML_EXPOSURE_INTEGRATION_LAYER
@@ -111,6 +111,61 @@ class LoaderTestCase(TestCase):
         self.assertEqual([
             'http://models.example.com/main/model.cellml',
         ], urlopener.external)
+
+    def test_extract_embeded_workspace_missing_registry(self):
+        su = getUtility(IStorageUtility, name='dummy_storage')
+        src = su._dummy_storage_data['demo_model'][0]['multi.cellml']
+
+        loaded = []
+
+        # patch urllib2.urlopen to return this exact result
+        def urlopen(request):
+            loaded.append(request.get_full_url())
+            return BytesIO(
+                su._dummy_storage_data['main_model'][0]['model.cellml'])
+
+        import urllib2
+        urllib2_urlopen, urllib2.urlopen = urllib2.urlopen, urlopen
+
+        def cleanup():
+            urllib2.urlopen = urllib2_urlopen
+
+        self.addCleanup(cleanup)
+
+        request = TestRequest(form={
+            'form.widgets.workspace': u'demo_model',
+            'form.widgets.commit_id': u'0',
+            'form.buttons.add': 1,
+        })
+        testform = ExposureAddForm(self.layer['portal'].exposure, request)
+        testform.update()
+        exp_id = testform._data['id']
+        context = self.layer['portal'].exposure[exp_id]
+        request = TestRequest(form={
+            'form.widgets.filename': [u'multi.cellml'],
+            'form.buttons.add': 1,
+        })
+        testform = ExposureFileGenForm(context, request)
+        testform.update()
+        exposure_file = context[u'multi.cellml']
+
+        loader = TrackedCellMLLoader()
+        urlopener = LoggedPmrUrlOpener()
+        result = sorted(loader.load(exposure_file, urlopener=urlopener).keys())
+
+        self.assertEqual([
+            u'main/model.cellml',
+            u'multi.cellml',
+        ], result)
+        # external is only measured if directly linked via absolute URIs
+        self.assertEqual([], urlopener.external)
+        # relative references through externally defined repositories
+        # will still be loaded.
+        self.assertEqual([
+            'http://nohost/plone/workspace/main_model/rawfile/0/model.cellml',
+            'http://nohost/plone/workspace/main_model/rawfile/0/model.cellml',
+            'http://nohost/plone/workspace/main_model/rawfile/0/model.cellml',
+        ], loaded)
 
 
 def test_suite():

--- a/src/pmr2/omex/tests/test_exposure_cellml.py
+++ b/src/pmr2/omex/tests/test_exposure_cellml.py
@@ -1,0 +1,119 @@
+from unittest import TestCase, TestSuite, makeSuite
+from io import BytesIO
+
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+
+from pmr2.app.workspace.interfaces import IStorageUtility
+from pmr2.app.exposure.browser.browser import ExposureAddForm
+from pmr2.app.exposure.browser.browser import ExposureFileGenForm
+from pmr2.testing.base import TestRequest
+
+from pmr2.omex.exposure.cellml import LoggedPmrUrlOpener
+from pmr2.omex.exposure.cellml import TrackedCellMLLoader
+
+from cellml.pmr2.tests.layer import CELLML_EXPOSURE_INTEGRATION_LAYER
+
+
+class LoaderTestCase(TestCase):
+
+    layer = CELLML_EXPOSURE_INTEGRATION_LAYER
+
+    def test_extract_single(self):
+        exposure_file = self.layer['portal'].unrestrictedTraverse(
+            self.layer['exposure_file1_path'])
+        loader = TrackedCellMLLoader()
+        result = sorted(loader.load(exposure_file).keys())
+        self.assertEqual([
+            'example_model.cellml'
+        ], result)
+
+    def test_extract_embeded_workspace_standard(self):
+        request = TestRequest(form={
+            'form.widgets.workspace': u'demo_model',
+            'form.widgets.commit_id': u'0',
+            'form.buttons.add': 1,
+        })
+        testform = ExposureAddForm(self.layer['portal'].exposure, request)
+        testform.update()
+        exp_id = testform._data['id']
+        context = self.layer['portal'].exposure[exp_id]
+        request = TestRequest(form={
+            'form.widgets.filename': [u'multi.cellml'],
+            'form.buttons.add': 1,
+        })
+        testform = ExposureFileGenForm(context, request)
+        testform.update()
+        exposure_file = context[u'multi.cellml']
+        registry = getUtility(IRegistry)
+        registry['cellml.pmr2.vhost.prefix_maps'] = {u'nohost': u''}
+
+        loader = TrackedCellMLLoader()
+        result = sorted(loader.load(exposure_file).keys())
+
+        self.assertEqual([
+            u'main/model.cellml',
+            u'multi.cellml',
+        ], result)
+
+    def test_extract_embeded_workspace_mixed_external(self):
+        # inject a modified version of the multi2 model
+        su = getUtility(IStorageUtility, name='dummy_storage')
+        src = su._dummy_storage_data['demo_model'][0]['multi.cellml']
+        lines = src.splitlines(True)
+        su._dummy_storage_data['demo_model'][0]['multi2.cellml'] = (
+            ''.join(lines[:19]) +
+            # modification involves a valid external import URI
+            lines[19].replace('href="', 'href="http://models.example.com/') +
+            ''.join(lines[20:])
+        )
+
+        # patch urllib2.urlopen to return this exact result
+        def urlopen(*a, **kw):
+            return BytesIO(
+                su._dummy_storage_data['main_model'][0]['model.cellml'])
+
+        import urllib2
+        urllib2_urlopen, urllib2.urlopen = urllib2.urlopen, urlopen
+
+        def cleanup():
+            urllib2.urlopen = urllib2_urlopen
+
+        self.addCleanup(cleanup)
+
+        request = TestRequest(form={
+            'form.widgets.workspace': u'demo_model',
+            'form.widgets.commit_id': u'0',
+            'form.buttons.add': 1,
+        })
+        testform = ExposureAddForm(self.layer['portal'].exposure, request)
+        testform.update()
+        exp_id = testform._data['id']
+        context = self.layer['portal'].exposure[exp_id]
+        request = TestRequest(form={
+            'form.widgets.filename': [u'multi2.cellml'],
+            'form.buttons.add': 1,
+        })
+        testform = ExposureFileGenForm(context, request)
+        testform.update()
+        exposure_file = context[u'multi2.cellml']
+        registry = getUtility(IRegistry)
+        registry['cellml.pmr2.vhost.prefix_maps'] = {u'nohost': u''}
+
+        loader = TrackedCellMLLoader()
+        urlopener = LoggedPmrUrlOpener()
+        result = sorted(loader.load(exposure_file, urlopener=urlopener).keys())
+
+        self.assertEqual([
+            u'main/model.cellml',
+            u'multi2.cellml',
+        ], result)
+        self.assertEqual([
+            'http://models.example.com/main/model.cellml',
+        ], urlopener.external)
+
+
+def test_suite():
+    suite = TestSuite()
+    suite.addTest(makeSuite(LoaderTestCase))
+    return suite

--- a/src/pmr2/omex/tests/test_exposure_default.py
+++ b/src/pmr2/omex/tests/test_exposure_default.py
@@ -1,7 +1,13 @@
 from unittest import TestCase
+
+import zipfile
+from io import BytesIO
+
 from zope.component import getUtility
 
 from pmr2.omex.exposure.interfaces import IExposureFileLoader
+from pmr2.omex.exposure.utility import ExposureGeneratedOmexArchiver
+
 from pmr2.omex.testing.layer import OMEX_EXPOSURE_INTEGRATION_LAYER
 
 
@@ -16,3 +22,14 @@ class LoaderTestCase(TestCase):
         self.assertEqual([
             'demo.xml'
         ], result)
+
+    def test_default_archive(self):
+        archiver = ExposureGeneratedOmexArchiver()
+        zipbytes = archiver.archive_exposure(
+            self.layer['portal'].ec.combine_test0)
+        zf = zipfile.ZipFile(BytesIO(zipbytes), mode='r')
+        self.assertEqual([
+            'demo.xml',
+            'manifest.xml',
+            'no_omex.xml',
+        ], sorted(zf.namelist()))

--- a/src/pmr2/omex/tests/test_exposure_default.py
+++ b/src/pmr2/omex/tests/test_exposure_default.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+from zope.component import getUtility
+
+from pmr2.omex.exposure.interfaces import IExposureFileLoader
+from pmr2.omex.testing.layer import OMEX_EXPOSURE_INTEGRATION_LAYER
+
+
+class LoaderTestCase(TestCase):
+
+    layer = OMEX_EXPOSURE_INTEGRATION_LAYER
+
+    def test_extract_single(self):
+        loader = getUtility(IExposureFileLoader)
+        exposure_file = self.layer['portal'].ec.combine_test0['demo.xml']
+        result = sorted(loader.load(exposure_file).keys())
+        self.assertEqual([
+            'demo.xml'
+        ], result)

--- a/src/pmr2/omex/tests/test_exposure_sedml.py
+++ b/src/pmr2/omex/tests/test_exposure_sedml.py
@@ -1,0 +1,72 @@
+import unittest
+
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+
+from pmr2.app.workspace.interfaces import IStorageUtility
+from pmr2.app.exposure.browser.browser import ExposureAddForm
+from pmr2.app.exposure.browser.browser import ExposureFileGenForm
+
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
+from pmr2.omex.exposure.sedml import TrackedSedMLLoader
+
+from pmr2.testing.base import TestRequest
+from plone.app.testing import IntegrationTesting
+from cellml.pmr2.tests.layer import CELLML_EXPOSURE_FIXTURE
+from pmr2.omex.testing.layer import OMEX_EXPOSURE_FIXTURE
+
+SEDML_INTEGRATION_LAYER = IntegrationTesting(
+    bases=(CELLML_EXPOSURE_FIXTURE, OMEX_EXPOSURE_FIXTURE,),
+    name="pmr2.omex:sedml_integration"
+)
+
+
+class SedMLTestCase(unittest.TestCase):
+
+    layer = SEDML_INTEGRATION_LAYER
+
+    def test_extract_embeded_workspace_mixed_external(self):
+        # inject a modified version of the multi2 model
+        su = getUtility(IStorageUtility, name='dummy_storage')
+        sedml = su._dummy_storage_data['sedml']
+        # hack a subrepo in there
+        sedml[-1]['embed'] = {
+            '': '_subrepo',
+            'rev': '0',
+            # XXX note the lack of portal in vhost
+            'location': 'http://nohost/plone/workspace/demo_model',
+        }
+
+        request = TestRequest(form={
+            'form.widgets.workspace': u'sedml',
+            'form.widgets.commit_id': u'0',
+            'form.buttons.add': 1,
+        })
+        testform = ExposureAddForm(self.layer['portal'].exposure, request)
+        testform.update()
+        exp_id = testform._data['id']
+        context = self.layer['portal'].exposure[exp_id]
+        request = TestRequest(form={
+            'form.widgets.filename': [u'simulation.sedml'],
+            'form.buttons.add': 1,
+        })
+        testform = ExposureFileGenForm(context, request)
+        testform.update()
+        exposure_file = context[u'simulation.sedml']
+        registry = getUtility(IRegistry)
+        registry['cellml.pmr2.vhost.prefix_maps'] = {u'nohost': u''}
+
+        loader = TrackedSedMLLoader()
+        urlopener = LoggedPmrUrlOpener()
+        result = sorted(loader.load(exposure_file, urlopener=urlopener).keys())
+
+        self.assertEqual([
+            u'demo.cellml',
+            u'embed/main/model.cellml',
+            u'embed/multi.cellml',
+            u'simulation.sedml',
+            u'table.csv',
+        ], result)
+        self.assertEqual([
+        ], urlopener.external)
+

--- a/src/pmr2/omex/tests/test_exposure_sedml.py
+++ b/src/pmr2/omex/tests/test_exposure_sedml.py
@@ -28,6 +28,32 @@ class SedMLTestCase(unittest.TestCase):
 
     layer = SEDML_INTEGRATION_LAYER
 
+    def test_simple(self):
+        request = TestRequest(form={
+            'form.widgets.workspace': u'sedml',
+            'form.widgets.commit_id': u'0',
+            'form.buttons.add': 1,
+        })
+        testform = ExposureAddForm(self.layer['portal'].exposure, request)
+        testform.update()
+        exp_id = testform._data['id']
+        context = self.layer['portal'].exposure[exp_id]
+
+        ExposureFileGenForm(context, TestRequest(form={
+            'form.widgets.filename': [u'simple.sedml'],
+            'form.buttons.add': 1,
+        })).update()
+
+        exposure_file = context[u'simple.sedml']
+        loader = TrackedSedMLLoader()
+        urlopener = LoggedPmrUrlOpener()
+        result = sorted(loader.load(exposure_file, urlopener=urlopener).keys())
+
+        self.assertEqual([
+            u'demo.cellml',
+            u'simple.sedml',
+        ], result)
+
     def test_extract_embeded_workspace_mixed_external(self):
         # inject a modified version of the multi2 model
         su = getUtility(IStorageUtility, name='dummy_storage')

--- a/src/pmr2/omex/tests/test_exposure_urlopener.py
+++ b/src/pmr2/omex/tests/test_exposure_urlopener.py
@@ -1,0 +1,48 @@
+from unittest import TestCase, TestSuite, makeSuite
+from io import BytesIO
+
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+
+from pmr2.app.workspace.interfaces import IStorageUtility
+from pmr2.app.exposure.browser.browser import ExposureAddForm
+from pmr2.app.exposure.browser.browser import ExposureFileGenForm
+from pmr2.testing.base import TestRequest
+
+from pmr2.omex.exposure.urlopener import LoggedPmrUrlOpener
+
+from cellml.pmr2.tests.layer import CELLML_EXPOSURE_INTEGRATION_LAYER
+
+
+class UrlOpenerTestCase(TestCase):
+
+    layer = CELLML_EXPOSURE_INTEGRATION_LAYER
+
+    def test_open_default(self):
+        exposure_file = self.layer['portal'].unrestrictedTraverse(
+            self.layer['exposure_file1_path'])
+        opener = LoggedPmrUrlOpener()
+        result = opener.loadURL(
+            'pmr:/plone/workspace/demo_model:0:/multi.cellml')
+        self.assertEqual({
+            'pmr:/plone/workspace/demo_model:0:/multi.cellml': result,
+        }, opener.loaded)
+
+    def test_open_embedded(self):
+        registry = getUtility(IRegistry)
+        registry['cellml.pmr2.vhost.prefix_maps'] = {u'nohost': u''}
+
+        exposure_file = self.layer['portal'].unrestrictedTraverse(
+            self.layer['exposure_file1_path'])
+        opener = LoggedPmrUrlOpener()
+        result = opener.loadURL(
+            'pmr:/plone/workspace/demo_model:0:/main/model.cellml')
+        self.assertEqual({
+            'pmr:/plone/workspace/demo_model:0:/main/model.cellml': result,
+        }, opener.loaded)
+
+
+def test_suite():
+    suite = TestSuite()
+    suite.addTest(makeSuite(UrlOpenerTestCase))
+    return suite

--- a/src/pmr2/omex/tests/test_omex.py
+++ b/src/pmr2/omex/tests/test_omex.py
@@ -1,6 +1,9 @@
 from unittest import TestCase, TestSuite, makeSuite
 
-from pmr2.omex.omex import build_omex, _process, parse_manifest
+from pmr2.omex.omex import (
+    parse_manifest,
+    generate_manifest,
+)
 
 demo_omex = '''<?xml version='1.0' encoding='utf-8' standalone='yes'?>
 <omexManifest
@@ -58,6 +61,35 @@ class TestOmex(TestCase):
             ['manifest.xml', 'BorisEJB.xml', 'paper/Kholodenko2000.pdf',
             'metadata.rdf'])
 
+    def test_generate_manifest(self):
+        manifest = generate_manifest({
+            'demo1.cellml': '',
+            'demo1.sedml': '',
+            'manifest.xml': '',
+            'metadata.rdf': '',
+            'image.png': '',
+        })
+        results = parse_manifest(manifest)
+        self.assertEqual(results, [
+            'demo1.cellml',
+            'demo1.sedml',
+            'image.png',
+            'manifest.xml',
+            'metadata.rdf',
+        ])
+        # just check that these are present int he output.
+        self.assertIn(
+            "http://identifiers.org/combine.specifications/cellml",
+            manifest,
+        )
+        self.assertIn(
+            "http://identifiers.org/combine.specifications/omex-metadata",
+            manifest,
+        )
+        self.assertIn(
+            "http://purl.org/NET/mediatypes/image/png",
+            manifest,
+        )
 
 def test_suite():
     suite = TestSuite()

--- a/src/pmr2/omex/tests/test_omex.py
+++ b/src/pmr2/omex/tests/test_omex.py
@@ -63,6 +63,7 @@ class TestOmex(TestCase):
 
     def test_generate_manifest(self):
         manifest = generate_manifest({
+            '.': '',
             'demo1.cellml': '',
             'demo1.sedml': '',
             'manifest.xml': '',
@@ -78,6 +79,11 @@ class TestOmex(TestCase):
             'metadata.rdf',
         ])
         # just check that these are present int he output.
+        self.assertIn(
+            '<content location="." '
+            'format="http://identifiers.org/combine.specifications/omex" />',
+            manifest,
+        )
         self.assertIn(
             "http://identifiers.org/combine.specifications/cellml",
             manifest,

--- a/src/pmr2/omex/utility.py
+++ b/src/pmr2/omex/utility.py
@@ -12,6 +12,7 @@ from pmr2.app.exposure.interfaces import IExposureFileTool
 
 from .interfaces import IOmexExposureArchiver
 from .omex import build_omex
+from .exposure.utility import ExposureGeneratedOmexArchiver
 
 
 @implementer(IStorageArchiver)
@@ -35,10 +36,10 @@ class OmexStorageArchiver(object):
 @implementer(IExposureDownloadTool)
 class OmexExposureDownloadTool(object):
     """
-    COMBINE Archive Download tool.
+    COMBINE Archive Download tool for a handcrafted manifest.
     """
 
-    label = u'COMBINE Archive'
+    label = u'COMBINE Archive (crafted)'
     suffix = '.omex'
     mimetype = 'application/vnd.combine.omex'
 
@@ -53,6 +54,28 @@ class OmexExposureDownloadTool(object):
             exposure_object, IOmexExposureArchiver)
         if archiver:
             return archiver()
+
+
+@implementer(IExposureDownloadTool)
+class OmexExposureGeneratedDownloadTool(object):
+    """
+    COMBINE Archive Download tool through the generated manifest.
+    """
+
+    label = u'COMBINE Archive (exposure)'
+    suffix = '.omex'
+    mimetype = 'application/vnd.combine.omex'
+
+    def get_download_link(self, exposure_object):
+        exposure, workspace, path = zope.component.getAdapter(
+            exposure_object, IExposureSourceAdapter).source()
+        return exposure.absolute_url() + '/download_generated_omex'
+
+    def download(self, exposure_object, request):
+        exposure, workspace, path = zope.component.getAdapter(
+            exposure_object, IExposureSourceAdapter).source()
+        archiver = ExposureGeneratedOmexArchiver()
+        return archiver.archive_exposure(exposure)
 
 
 def OmexExposureArchiverFactory(exposure_object):


### PR DESCRIPTION
Currently this draft branch only include the most annoying bits which are the resolution of the relative imports for both initial supported file types, leveraging the existing work already done for aiding the CellML API in fetching model files from PMR.

Yes embedded workspace references are going to be resolved.

When this is merged it will fix #1.